### PR TITLE
Offer the unminified package by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "validate",
 	"version": "1.0.5",
 	"description": "A lightweight form validation script that augments native HTML5 form validation elements and attributes.",
-	"main": "./dist/js/validate.min.js",
+	"main": "./dist/js/validate.js",
 	"author": {
 		"name": "Chris Ferdinandi",
 		"url": "http://gomakethings.com"


### PR DESCRIPTION
While the minified package is useful for developers who just want to get started quickly and download the package, I’d imagine that most people pulling the package in via NPM or equivalent will have their own minification setup. In this case it doesn’t save time and makes it harder to debug the library.