### PR TITLE
Properly destroy the blur event handler

### DIFF
--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -414,7 +414,7 @@
 		if ( !settings ) return;
 
 		// Remove event listeners
-		document.removeEventListener('blur', blurHandler, false);
+		document.removeEventListener('blur', blurHandler, true);
 		document.removeEventListener('submit', submitHandler, false);
 
 		// Remove all errors


### PR DESCRIPTION
The blur event handler is registered as capturing, but the destroy function attempts to remove a non-capturing handler that doesn’t exist.