### PR TITLE
Allow non-block styling of the error message

### DIFF
--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -263,9 +263,9 @@
 		// Update error message
 		message.innerHTML = error;
 
-		// Show error message
-		message.style.display = 'block';
-		message.style.visibility = 'visible';
+		// Remove any existing styles hiding the error message
+		message.style.display = '';
+		message.style.visibility = '';
 
 		// After show error callback
 		localSettings.afterShowError(field, error);


### PR DESCRIPTION
Currently the code flips the error message between an inline `display:block` for visible and `display:none` for hidden. This works, but doesn’t let us apply our own `display` styles for the error message in our CSS (e.g. `display:inline`). Those styles will be overridden regardless of the error message’s state.

A better approach is to continue using `display:none` for the hidden state, and to simply remove it for the visible state. That way the styling will fall back to whatever display style is defined in the page’s CSS, or back to the default display for `div`s (`block`) in its absence.

The same applies for the `visibility` rule.