### PR TITLE
Fixed hasError to also return custom error messages

### DIFF
--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -195,6 +195,9 @@
 
 		}
 
+		// If custom error
+		if (validity.customError) return field.validationMessage;
+
 		// If all else fails, return a generic catchall error
 		return localSettings.messageGeneric;
 


### PR DESCRIPTION
Error messages set by `setCustomValidity` was ignored.