### PR TITLE
Change to default errors IDs so that square brackets are subbed for hyphens 

### DIFF
--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -239,8 +239,8 @@
 			}
 		}
 
-		// Get field id or name
-		var id = field.id || field.name;
+    // Get field's id, or use name with square brackets removed
+    var id = field.id || field.name.replace(/[\[\]]/g, '-');
 		if (!id) return;
 
 		// Check if error message field already exists
@@ -313,8 +313,8 @@
 			}
 		}
 
-		// Get field id or name
-		var id = field.id || field.name;
+    // Get field's id, or use name with square brackets removed
+    var id = field.id || field.name.replace(/[\[\]]/g, '-');
 		if (!id) return;
 
 		// Check if an error message is in the DOM


### PR DESCRIPTION
A small suggestion about subbing square brackets for hyphens when the error IDs are copied directly from the field name .

In my use case in Rails, fields with names such as 'user[profile_attributes][username]' were producing default IDs that weren't searchable with querySelector. A value of null is returned instead of the DOM node.
 Eg - document.querySelecter('.form-error-message#error-for-user[email]')  -> null

This means the errors stack up as the function to remove them isn't finding the element. 

I was unable to run the Gulp build unfortunately. Please advise on version number changes 