### PR TITLE
Update validate.js

### DIFF
--- a/src/js/validate.js
+++ b/src/js/validate.js
@@ -204,6 +204,10 @@
 
 		}
 
+		// If has custom error, return it
+		if(field.validity.customError){
+		    return field.validationMessage;
+		}
 		// If all else fails, return a generic catchall error
 		return localSettings.messageGeneric;
 


### PR DESCRIPTION
If you make your own validation (e.g. I had to compare the values of 2 fields) using 
field.setCustomValidity(customErrorMessageOfSomeKind)
the generic error will currently be shown, just have to add these 3 lines to catch the right error message (I apologize for being lazy and just changing this one file and not in the dist folder etc.)